### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,6 +266,7 @@ Links
 -----
 * `Project home page (GitHub) <https://github.com/kislyuk/watchtower>`_
 * `Documentation (Read the Docs) <https://watchtower.readthedocs.io/en/latest/>`_
+* `Reference Docs (Contour) <https://docs.contour.so/AuraVisionLabs/watchtower/getting-started>`_
 * `Package distribution (PyPI) <https://pypi.python.org/pypi/watchtower>`_
 * `AWS CLI CloudWatch Logs plugin <https://pypi.python.org/pypi/awscli-cwlogs>`_
 * `Docker awslogs adapter <https://github.com/docker/docker/blob/master/daemon/logger/awslogs/cloudwatchlogs.go>`_


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!